### PR TITLE
Allow multiple realign passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ python3 align.py audio.mp3 words.txt
 ```
 
 The default behaviour outputs the JSON to stdout.  See `python3 align.py --help` for options.
+You can control how many realignment passes are run with the `--realign-passes`
+option (default is `3`).

--- a/align.py
+++ b/align.py
@@ -26,6 +26,9 @@ parser.add_argument(
         '--log', default="INFO",
         help='the log level (DEBUG, INFO, WARNING, ERROR, or CRITICAL)')
 parser.add_argument(
+        '--realign-passes', dest='realign_passes', type=int, default=3,
+        help='number of realignment passes to run after initial alignment')
+parser.add_argument(
         'audiofile', type=str,
         help='audio file')
 parser.add_argument(
@@ -51,7 +54,15 @@ logging.info("converting audio to 8K sampled wav")
 
 with gentle.resampled(args.audiofile) as wavfile:
     logging.info("starting alignment")
-    aligner = gentle.ForcedAligner(resources, transcript, nthreads=args.nthreads, disfluency=args.disfluency, conservative=args.conservative, disfluencies=disfluencies)
+    aligner = gentle.ForcedAligner(
+        resources,
+        transcript,
+        nthreads=args.nthreads,
+        disfluency=args.disfluency,
+        conservative=args.conservative,
+        disfluencies=disfluencies,
+        realign_passes=args.realign_passes,
+    )
     result = aligner.transcribe(wavfile, progress_cb=on_progress, logging=logging)
 
 fh = open(args.output, 'w', encoding="utf-8") if args.output else sys.stdout

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -8,9 +8,27 @@ from gentle.transcription import Transcription
 
 class ForcedAligner():
 
-    def __init__(self, resources, transcript, nthreads=4, **kwargs):
+    def __init__(self, resources, transcript, nthreads=4, realign_passes=3, **kwargs):
+        """Create a new ``ForcedAligner``.
+
+        Parameters
+        ----------
+        resources : :class:`gentle.Resources`
+            Model and binary resources needed for alignment.
+        transcript : str
+            Transcript to align with the provided audio.
+        nthreads : int, optional
+            Number of Kaldi workers to run in parallel.
+        realign_passes : int, optional
+            Number of multipass realignment iterations to run after the
+            initial alignment.  The default (``3``) results in four total
+            alignment passes.
+        **kwargs : dict
+            Passed through to the language model builder and aligner.
+        """
         self.kwargs = kwargs
         self.nthreads = nthreads
+        self.realign_passes = max(realign_passes, 0)
         self.transcript = transcript
         self.resources = resources
         self.ms = metasentence.MetaSentence(transcript, resources.vocab)
@@ -30,17 +48,34 @@ class ForcedAligner():
         # Align words
         words = diff_align.align(words, self.ms, **self.kwargs)
 
-        # Perform a second-pass with unaligned words
+        # Optionally perform additional passes on unaligned words
         if logging is not None:
             logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
-        if progress_cb is not None:
-            progress_cb({'status': 'ALIGNING'})
+        for i in range(self.realign_passes):
+            if progress_cb is not None:
+                progress_cb({'status': 'ALIGNING'})
 
-        words = multipass.realign(wavfile, words, self.ms, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
+            if not any(X.not_found_in_audio() for X in words):
+                break
 
-        if logging is not None:
-            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
+            words = multipass.realign(
+                wavfile,
+                words,
+                self.ms,
+                resources=self.resources,
+                nthreads=self.nthreads,
+                progress_cb=progress_cb,
+            )
+
+            if logging is not None:
+                logging.info(
+                    "after realign pass %d: %d unaligned words (of %d)" % (
+                        i + 1,
+                        len([X for X in words if X.not_found_in_audio()]),
+                        len(words),
+                    )
+                )
 
         words = AdjacencyOptimizer(words, duration).optimize()
 

--- a/serve.py
+++ b/serve.py
@@ -145,9 +145,16 @@ class TranscriptionsController(Resource):
 
         disfluency = True if b'disfluency' in req.args else False
         conservative = True if b'conservative' in req.args else False
-        kwargs = {'disfluency': disfluency,
-                  'conservative': conservative,
-                  'disfluencies': set(['uh', 'um'])}
+        kwargs = {
+            'disfluency': disfluency,
+            'conservative': conservative,
+            'disfluencies': set(['uh', 'um']),
+        }
+        if b'realign_passes' in req.args:
+            try:
+                kwargs['realign_passes'] = int(req.args[b'realign_passes'][0])
+            except ValueError:
+                pass
 
         async_mode = True
         if b'async' in req.args and req.args[b'async'][0] == b'false':


### PR DESCRIPTION
## Summary
- expose `realign_passes` in `ForcedAligner`
- loop over multipass realignment passes
- plumb new option through CLI and server
- document new command line option
- default to 3 realign passes (4 total passes)

## Testing
- `pytest -q tests/base.py` *(fails: No resource directory /workspace/gentle/exp)*
- `pytest -q tests/transcriber.py` *(fails: No resource directory /workspace/gentle/exp)*


------
https://chatgpt.com/codex/tasks/task_e_6849d702130c832e85a376e9e6ab2c72